### PR TITLE
Fix/230 timezone tests

### DIFF
--- a/src/utils/helpers/date/formatTimestamp/formatTimestamp.test.ts
+++ b/src/utils/helpers/date/formatTimestamp/formatTimestamp.test.ts
@@ -1,7 +1,9 @@
 import { formatTimestamp } from './formatTimestamp';
 
+vi.useFakeTimers().setSystemTime(new Date('1999-03-12'));
+
 describe('formatTimestamp', () => {
   it('Should correctly format timestamp', () => {
-    expect(formatTimestamp(1735623296789)).toBe('31.12.2024, 12:34:56,789');
+    expect(formatTimestamp(944199296789)).toBe('03.12.1999, 12:34:56,789');
   });
 });

--- a/src/utils/helpers/date/formatTimestamp/formatTimestamp.test.ts
+++ b/src/utils/helpers/date/formatTimestamp/formatTimestamp.test.ts
@@ -1,9 +1,7 @@
 import { formatTimestamp } from './formatTimestamp';
 
-vi.useFakeTimers().setSystemTime(new Date('1999-03-12'));
-
 describe('formatTimestamp', () => {
   it('Should correctly format timestamp', () => {
-    expect(formatTimestamp(944199296789)).toBe('03.12.1999, 12:34:56,789');
+    expect(formatTimestamp(1735623296789)).toBe('31.12.2024, 05:34:56,789');
   });
 });

--- a/src/utils/helpers/logger/callRequestLogger/callRequestLogger.test.ts
+++ b/src/utils/helpers/logger/callRequestLogger/callRequestLogger.test.ts
@@ -25,7 +25,7 @@ describe('callRequestLogger', () => {
       {
         type: 'request',
         id: 1,
-        timestamp: '31.12.2024, 12:34:56,789',
+        timestamp: '31.12.2024, 05:34:56,789',
         method: 'POST',
         url: 'http://host/api/rest/posts/2'
       },
@@ -38,7 +38,7 @@ describe('callRequestLogger', () => {
       {
         type: 'request',
         id: 1,
-        timestamp: '31.12.2024, 12:34:56,789',
+        timestamp: '31.12.2024, 05:34:56,789',
         method: 'POST',
         url: 'http://host/api/rest/posts/2'
       },

--- a/src/utils/helpers/logger/callResponseLogger/callResponseLogger.test.ts
+++ b/src/utils/helpers/logger/callResponseLogger/callResponseLogger.test.ts
@@ -33,7 +33,7 @@ describe('callResponseLogger', () => {
       {
         type: 'response',
         id: 1,
-        timestamp: '31.12.2024, 12:34:56,789',
+        timestamp: '31.12.2024, 05:34:56,789',
         method: 'POST',
         url: 'http://host/api/rest/posts/2',
         statusCode: 200,
@@ -48,7 +48,7 @@ describe('callResponseLogger', () => {
       {
         type: 'response',
         id: 1,
-        timestamp: '31.12.2024, 12:34:56,789',
+        timestamp: '31.12.2024, 05:34:56,789',
         method: 'POST',
         url: 'http://host/api/rest/posts/2',
         statusCode: 200,

--- a/src/utils/helpers/logger/helpers/formatTokens/formatTokens.test.ts
+++ b/src/utils/helpers/logger/helpers/formatTokens/formatTokens.test.ts
@@ -11,7 +11,7 @@ describe('formatTokens', () => {
     const result = formatTokens(tokens);
 
     expect(result).toStrictEqual({
-      timestamp: '31.12.2024, 12:34:56,789',
+      timestamp: '31.12.2024, 05:34:56,789',
       method: 'GET',
       statusCode: 200
     });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,11 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     ...vitest,
-    environment: 'node'
+    environment: 'node',
+    pool: 'forks',
+    env: {
+      TZ: 'UTC'
+    }
   },
   resolve: {
     alias: {


### PR DESCRIPTION
same
https://github.com/stryker-mutator/stryker-js/issues/5982
https://github.com/vitest-dev/vitest/discussions/1718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized timestamp formatting in logging and utility tests to use UTC values.
  * Improved test consistency for formatted request and response timestamps.

* **Tests**
  * Updated the test environment configuration to run in UTC with isolated test processes, reducing timezone-dependent test variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->