### PR TITLE
fix: routing for Next Steps cards in getting started guide

### DIFF
--- a/packages/docs/content/docs/introduction/getting-started.mdx
+++ b/packages/docs/content/docs/introduction/getting-started.mdx
@@ -105,18 +105,18 @@ This guide is a good starting point, but you can do so much more with mock-confi
 <Cards>
   <Card
     title='Introducing'
-    href='/docs/server/introducing'
+    href='/docs/mocking-requests/introducing'
     description='Learn about the core concepts of mock-config-server'
   />
 <Card
   title="REST"
-  href="/docs/server/rest"
+  href="/docs/mocking-requests/references/Rest"
   description="Build REST API mocks with ease"
 />
 
 <Card
   title='GraphQL'
-  href='/docs/server/graphql'
+  href='/docs/mocking-requests/references/GraphQL'
   description='Create GraphQL API mocks and queries'
 />
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,9 @@ allowBuilds:
 publicHoistPattern:
   - eslint
   - prettier
+supportedArchitectures:
+  os:
+    - current
+  cpu:
+    - x64
+    - arm64


### PR DESCRIPTION
## Changes

- Fixed broken links in the **Next Steps** cards of the getting started guide — they pointed to the non-existent `/docs/server/*` section (actual section is `mocking-requests`), causing 404s
- Added `supportedArchitectures` (x64 + arm64) to `pnpm-workspace.yaml` so native binaries (esbuild, swc) work for both architectures on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)